### PR TITLE
Replace the notification text on legacy CC Search

### DIFF
--- a/index.php
+++ b/index.php
@@ -245,7 +245,7 @@ function modRights($engine, $comm, $deriv) {
 
         <div class="first row">
         <div class="sixteen columns alpha wrong">
-        <h3><?php echo _('<a href="https://ccsearch.creativecommons.org">Try the new CC Search beta</a>, with list-making and one-click attribution!'); ?></h3>
+        <h3><?php echo _('Try the new CC Search for images <a href="https://ccsearch.creativecommons.org">here</a>!'); ?></h3>
         </div>
         </div>
 


### PR DESCRIPTION
This PR addresses creativecommons/cccatalog-frontend#288 raised by @janeatcc

Instead of 
> Try the new CC Search beta, with list-making and one-click attribution!

it now reads 
> Try the new CC Search for images here!

I could not find any translations for this tool in languages apart from English so this lone change should suffice to solve the mentioned issue.

<details>
<summary>Developer Certificate of Origin
Version 1.1
</summary>
<p>
Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
</p>