### PR TITLE
Bug fix/thingiverse

### DIFF
--- a/index.php
+++ b/index.php
@@ -75,7 +75,7 @@ if ( isset($_REQUEST['engine']) && $_REQUEST['query'] != "" ) {
 			if ($comm) {
 				// Defer to OpenVerse (with search refined only to Thingiverse items) until Thingiverse licence search filter issue is fixed
 				// TODO Use Thingiverse search filters when issue is fixed and
-				$url = 'https://wordpress.org/openverse/search/image?q=' . $query . '&license_type=commercial&source=thingiverse' . $rights;
+				$url = 'https://wordpress.org/openverse/search/image?q=' . $query . '&source=thingiverse' . $rights;
 			} else {
 				$url = 'https://www.thingiverse.com/search?q=' . $query . $rights;
 			}

--- a/index.php
+++ b/index.php
@@ -72,13 +72,10 @@ if ( isset($_REQUEST['engine']) && $_REQUEST['query'] != "" ) {
 			break;
 
 		case "thingiverse":
-			if ($comm) {
-				// Defer to OpenVerse (with search refined only to Thingiverse items) until Thingiverse licence search filter issue is fixed
-				// TODO Use Thingiverse search filters when issue is fixed and
-				$url = 'https://wordpress.org/openverse/search/image?q=' . $query . '&source=thingiverse' . $rights;
-			} else {
-				$url = 'https://www.thingiverse.com/search?q=' . $query . $rights;
-			}
+			// Defer to OpenVerse (with search refined only to Thingiverse items) until Thingiverse licence search filter issue is fixed
+			// TODO Use Thingiverse search filters when issue is fixed and
+			$url = 'https://wordpress.org/openverse/search/image?q=' . $query . '&source=thingiverse' . $rights;
+			// $url = 'https://www.thingiverse.com/search?q=' . $query . $rights;
 			break;
 
 		case "sketchfab":
@@ -137,11 +134,11 @@ function modRights($engine, $comm, $deriv) {
 				the "customizable" and "licence" filters on thingiverse only work alongside the "things" filter
 			*/
 
-			if ($comm) {
+			if ($comm || $deriv) {
 				// Defer to OpenVerse (with search refined only to Thingiverse items) until Thingiverse licence search filter issue is fixed
 				// TODO Use Thingiverse search filters when issue is fixed and
 
-				// Replicate Openverse rights when commercial filter selected
+				// Replicate Openverse rights when commercial and/or modify filters selected
 				$rights = '&license_type=';
 				if( $comm && $deriv){
 					$rights .= "commercial,modification";
@@ -151,17 +148,17 @@ function modRights($engine, $comm, $deriv) {
 					$rights .= "modification";
 				}
 
-			} else {
-				if ($comm || $deriv) {
-					$rights = "&type=things&sort=relevant";
-					$rights .= $deriv ? "&customizable=1" : "";
+			} 
+			// else {
+			// 	if ($comm || $deriv) {
+			// 		$rights = "&type=things&sort=relevant";
+			// 		$rights .= $deriv ? "&customizable=1" : "";
 	
-					// Used the licence=cc (which on Thingiverse, stands for the Creative Commons Attribution license)
-					// as the equivalent for the "modify, reuse ..." filter on CC search
-					$rights .= $comm ? "&license=cc": "";
-				}
-			}
-			
+			// 		// Used the licence=cc (which on Thingiverse, stands for the Creative Commons Attribution license)
+			// 		// as the equivalent for the "modify, reuse ..." filter on CC search
+			// 		$rights .= $comm ? "&license=cc": "";
+			// 	}
+			// }
 
 			break;
 

--- a/index.php
+++ b/index.php
@@ -72,7 +72,13 @@ if ( isset($_REQUEST['engine']) && $_REQUEST['query'] != "" ) {
 			break;
 
 		case "thingiverse":
-			$url = 'https://www.thingiverse.com/search?q=' . $query . $rights;
+			if ($comm) {
+				// Defer to OpenVerse (with search refined only to Thingiverse items) until Thingiverse licence search filter issue is fixed
+				// TODO Use Thingiverse search filters when issue is fixed and
+				$url = 'https://wordpress.org/openverse/search/image?q=' . $query . '&license_type=commercial&source=thingiverse' . $rights;
+			} else {
+				$url = 'https://www.thingiverse.com/search?q=' . $query . $rights;
+			}
 			break;
 
 		case "sketchfab":
@@ -126,14 +132,32 @@ function modRights($engine, $comm, $deriv) {
 				to capture only results of type "things" before adding the specifics we require because
 				the "customizable" and "licence" filters on thingiverse only work alongside the "things" filter
 			*/
-			if ($comm || $deriv) {
-				$rights = "&type=things&sort=relevant";
-				$rights .= $deriv ? "&customizable=1" : "";
 
-				// Used the licence=cc (which on Thingiverse, stands for the Creative Commons Attribution license)
-				// as the equivalent for the "modify, reuse ..." filter on CC search
-				$rights .= $comm ? "&license=cc": "";
+			if ($comm) {
+				// Defer to OpenVerse (with search refined only to Thingiverse items) until Thingiverse licence search filter issue is fixed
+				// TODO Use Thingiverse search filters when issue is fixed and
+
+				// Replicate Openverse rights when commercial filter selected
+				$rights = '&license_type=';
+				if( $comm && $deriv){
+					$rights .= "commercial,modification";
+				} elseif($comm){
+					$rights .= "commercial";
+				}elseif($deriv){
+					$rights .= "modification";
+				}
+
+			} else {
+				if ($comm || $deriv) {
+					$rights = "&type=things&sort=relevant";
+					$rights .= $deriv ? "&customizable=1" : "";
+	
+					// Used the licence=cc (which on Thingiverse, stands for the Creative Commons Attribution license)
+					// as the equivalent for the "modify, reuse ..." filter on CC search
+					$rights .= $comm ? "&license=cc": "";
+				}
 			}
+			
 
 			break;
 

--- a/search.js
+++ b/search.js
@@ -367,13 +367,30 @@ function modRights() {
 				to capture only results of type "things" before adding the specifics we require because
 				the "customizable" and "licence" filters on thingiverse only work alongside the "things" filter
 			*/
-			if (comm || deriv) {
-				rights = "&type=things&sort=relevant";
-				rights += deriv ? "&customizable=1" : "";
 
-				// Used the licence=cc (which on Thingiverse, stands for the Creative Commons Attribution license)
-				// as the equivalent for the "modify, reuse ..." filter on CC search
-				rights += comm ? "&license=cc": "";
+			if (comm) {
+				// Defer to OpenVerse (with search refined only to Thingiverse items) until Thingiverse licence search filter issue is fixed
+				// TODO Use Thingiverse search filters when issue is fixed and
+
+				// Replicate Openverse rights when commercial filter selected
+				rights = '&license_type=';
+				if(comm && $deriv){
+					rights += "commercial,modification";
+				} else if(comm){
+					rights += "commercial";
+				}else if(deriv){
+					rights += "modification";
+				}
+
+			} else {
+				if (comm || deriv) {
+					rights = "&type=things&sort=relevant";
+					rights += deriv ? "&customizable=1" : "";
+	
+					// Used the licence=cc (which on Thingiverse, stands for the Creative Commons Attribution license)
+					// as the equivalent for the "modify, reuse ..." filter on CC search
+					rights += comm ? "&license=cc": "";
+				}
 			}
 
 			break;
@@ -579,7 +596,13 @@ function doSearch() {
 				break;
 
 			case "thingiverse":
-				url = 'https://www.thingiverse.com/search?q=' + query.val() + rights;
+				if ($comm) {
+					// Defer to OpenVerse (with search refined only to Thingiverse items) until Thingiverse licence search filter issue is fixed
+					// TODO Use Thingiverse search filters when issue is fixed and
+					url = 'https://wordpress.org/openverse/search/image?q=' + $query.val() + '&license_type=commercial&source=thingiverse' . $rights;
+				} else {
+					url = 'https://www.thingiverse.com/search?q=' + query.val() + rights;
+				}
 				break;
 
 			case "sketchfab":

--- a/search.js
+++ b/search.js
@@ -368,11 +368,11 @@ function modRights() {
 				the "customizable" and "licence" filters on thingiverse only work alongside the "things" filter
 			*/
 
-			if (comm) {
+			if (comm || deriv) {
 				// Defer to OpenVerse (with search refined only to Thingiverse items) until Thingiverse licence search filter issue is fixed
 				// TODO Use Thingiverse search filters when issue is fixed and
 
-				// Replicate Openverse rights when commercial filter selected
+				// Replicate Openverse rights when commercial and/or modify filters selected
 				rights = '&license_type=';
 				if(comm && deriv){
 					rights += "commercial,modification";
@@ -382,16 +382,17 @@ function modRights() {
 					rights += "modification";
 				}
 
-			} else {
-				if (comm || deriv) {
-					rights = "&type=things&sort=relevant";
-					rights += deriv ? "&customizable=1" : "";
+			}  
+			// else {
+			// 	if (comm || deriv) {
+			// 		rights = "&type=things&sort=relevant";
+			// 		rights += deriv ? "&customizable=1" : "";
 	
-					// Used the licence=cc (which on Thingiverse, stands for the Creative Commons Attribution license)
-					// as the equivalent for the "modify, reuse ..." filter on CC search
-					rights += comm ? "&license=cc": "";
-				}
-			}
+			// 		// Used the licence=cc (which on Thingiverse, stands for the Creative Commons Attribution license)
+			// 		// as the equivalent for the "modify, reuse ..." filter on CC search
+			// 		rights += comm ? "&license=cc": "";
+			// 	}
+			// }
 
 			break;
 		
@@ -596,13 +597,10 @@ function doSearch() {
 				break;
 
 			case "thingiverse":
-				if (comm) {
-					// Defer to OpenVerse (with search refined only to Thingiverse items) until Thingiverse licence search filter issue is fixed
-					// TODO Use Thingiverse search filters when issue is fixed and
-					url = 'https://wordpress.org/openverse/search/image?q=' + query.val() + '&source=thingiverse' + rights;
-				} else {
-					url = 'https://www.thingiverse.com/search?q=' + query.val() + rights;
-				}
+				// Defer to OpenVerse (with search refined only to Thingiverse items) until Thingiverse licence search filter issue is fixed
+				// TODO Use Thingiverse search filters when issue is fixed and
+				url = 'https://wordpress.org/openverse/search/image?q=' + query.val() + '&source=thingiverse' + rights;
+				// url = 'https://www.thingiverse.com/search?q=' + query.val() + rights;
 				break;
 
 			case "sketchfab":

--- a/search.js
+++ b/search.js
@@ -374,11 +374,11 @@ function modRights() {
 
 				// Replicate Openverse rights when commercial filter selected
 				rights = '&license_type=';
-				if(comm && $deriv){
+				if(comm && deriv){
 					rights += "commercial,modification";
 				} else if(comm){
 					rights += "commercial";
-				}else if(deriv){
+				} else if(deriv){
 					rights += "modification";
 				}
 
@@ -596,10 +596,10 @@ function doSearch() {
 				break;
 
 			case "thingiverse":
-				if ($comm) {
+				if (comm) {
 					// Defer to OpenVerse (with search refined only to Thingiverse items) until Thingiverse licence search filter issue is fixed
 					// TODO Use Thingiverse search filters when issue is fixed and
-					url = 'https://wordpress.org/openverse/search/image?q=' + $query.val() + '&license_type=commercial&source=thingiverse' . $rights;
+					url = 'https://wordpress.org/openverse/search/image?q=' + query.val() + '&source=thingiverse' + rights;
 				} else {
 					url = 'https://www.thingiverse.com/search?q=' + query.val() + rights;
 				}


### PR DESCRIPTION
## Fixes
Fixes #123 by @TimidRobot 

## Description
When the _"commercial purposes"_ checkbox on CC search portal is checked, [Thingiverse](https://www.thingiverse.com/search?q=cats&page=1&type=things&sort=relevant&license=cc) always displays no results.
Redirected to [Openverse](https://wordpress.org/openverse/search/image/?q=cat&license_type=commercial,modification&source=thingiverse) search when the commercial checkbox is checked. 
The code can be restored when the issue on Thingiverse is fixed


## Technical details
- Included an if clause to check if "_commercial purposes_" checkbox was selected and redirected to [OpenVerse](https://wordpress.org/openverse/search/image/?q=cat&license_type=commercial,modification&source=thingiverse) (with Thingiverse source specified in the query).
- Included a "_TODO_" in the code in order to restore the thingiverse license filters action when it is fixed.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
