### PR TITLE
adds the aria-label attribute to all the engine buttons.

### DIFF
--- a/index.php
+++ b/index.php
@@ -333,7 +333,7 @@ function modRights($engine, $comm, $deriv) {
                         <div class="four columns alpha">
 						<div class="engine">
 							<div class="engineButton">
-								<button onclick="setEngine(this)" name="engine" value="ccmixter" id="ccmixter"></button>
+								<button onclick="setEngine(this)" name="engine" value="ccmixter" id="ccmixter" aria-label="ccMixter"></button>
 							</div>
 							<div class="engineDesc"><label for="ccmixter"><strong>ccMixter</strong><br/>Music</label></div>
 						</div>
@@ -341,7 +341,7 @@ function modRights($engine, $comm, $deriv) {
                         <div class="four columns">
 						<div class="engine">
 							<div class="engineButton">
-								<button onclick="setEngine(this)" name="engine" value="europeana" id="europeana"></button>
+								<button onclick="setEngine(this)" name="engine" value="europeana" id="europeana" aria-label="Europeana"></button>
 							</div>
 							<div class="engineDesc"><label for="europeana"><strong>Europeana</strong><br/>Media</label></div>
 						</div>
@@ -349,7 +349,7 @@ function modRights($engine, $comm, $deriv) {
                         <div class="four columns">
 						<div class="engine">
 							<div class="engineButton">
-								<button onclick="setEngine(this)" name="engine" value="flickr" id="flickr"></button>
+								<button onclick="setEngine(this)" name="engine" value="flickr" id="flickr" aria-label="Flickr"></button>
 							</div>
 							<div class="engineDesc"><label for="flickr"><strong>Flickr</strong><br/>Image</label></div>
 						</div>
@@ -357,7 +357,7 @@ function modRights($engine, $comm, $deriv) {
                         <div class="four columns omega">
 						<div class="engine">
 							<div class="engineButton">
-								<button onclick="setEngine(this)" name="engine" value="google" id="google"></button>
+								<button onclick="setEngine(this)" name="engine" value="google" id="google" aria-label="Google"></button>
 							</div>
 							<div class="engineDesc"><label for="google"><strong>Google</strong><br/>Web</label></div>
 						</div>
@@ -367,7 +367,7 @@ function modRights($engine, $comm, $deriv) {
                         <div class="four columns alpha">
 						<div class="engine">
 							<div class="engineButton">
-								<button onclick="setEngine(this)" name="engine" value="googleimg" id="googleimg"></button>
+								<button onclick="setEngine(this)" name="engine" value="googleimg" id="googleimg" aria-label="Google Images"></button>
 							</div>
 							<div class="engineDesc"><label for="googleimg"><strong>Google Images</strong><br/>Image</label></div>
 						</div>
@@ -375,7 +375,7 @@ function modRights($engine, $comm, $deriv) {
                         <div class="four columns">
 						<div class="engine">
 							<div class="engineButton">
-								<button onclick="setEngine(this)" name="engine" value="jamendo" id="jamendo"></button>
+								<button onclick="setEngine(this)" name="engine" value="jamendo" id="jamendo" aria-label="Jamendo"></button>
 							</div>
 							<div class="engineDesc"><label for="jamendo"><strong>Jamendo</strong><br/>Music</label></div>
 						</div>
@@ -383,7 +383,7 @@ function modRights($engine, $comm, $deriv) {
                         <div class="four columns">
 						<div class="engine">
 							<div class="engineButton">
-								<button onclick="setEngine(this)" name="engine" value="nappy" id="nappy"></button>
+								<button onclick="setEngine(this)" name="engine" value="nappy" id="nappy" aria-label="Nappy"></button>
 							</div>
 							<div class="engineDesc"><label for="nappy"><strong>Nappy</strong><br/>image</label></div>
 						</div>
@@ -391,7 +391,7 @@ function modRights($engine, $comm, $deriv) {
 						<div class="four columns omega">
 						<div class="engine">
 							<div class="engineButton">
-								<button onclick="setEngine(this)" name="engine" value="openclipart" id="openclipart"></button>
+								<button onclick="setEngine(this)" name="engine" value="openclipart" id="openclipart" aria-label="Open ClipArt"></button>
 							</div>
 							<div class="engineDesc"><label for="openclipart"><strong>Open ClipArt</strong><br/>Image</label></div>
 						</div>
@@ -401,7 +401,7 @@ function modRights($engine, $comm, $deriv) {
 						<div class="four columns alpha">
 						<div class="engine">
 							<div class="engineButton">
-								<button onclick="setEngine(this)" name="engine" value="openverse" id="openverse"></button>
+								<button onclick="setEngine(this)" name="engine" value="openverse" id="openverse" aria-label="Openverse"></button>
 							</div>
 							<div class="engineDesc"><label for="openverse"><strong>Openverse</strong><br/>Media</label></div>
 						</div>
@@ -409,7 +409,7 @@ function modRights($engine, $comm, $deriv) {
                         <div class="four columns">
 						<div class="engine">
 							<div class="engineButton">
-								<button onclick="setEngine(this)" name="engine" value="sketchfab" id="sketchfab"></button>
+								<button onclick="setEngine(this)" name="engine" value="sketchfab" id="sketchfab" aria-label="Sketchfab"></button>
 							</div>
 							<div class="engineDesc"><label for="sketchfab"><strong>Sketchfab</strong><br/>3D Model</label></div>
 						</div>
@@ -417,7 +417,7 @@ function modRights($engine, $comm, $deriv) {
 						<div class="four columns">
 						<div class="engine">
 							<div class="engineButton">
-								<button onclick="setEngine(this)" name="engine" value="soundcloud" id="soundcloud"></button>
+								<button onclick="setEngine(this)" name="engine" value="soundcloud" id="soundcloud" aria-label="SoundCloud"></button>
 							</div>
 							<div class="engineDesc"><label for="soundcloud"><strong>SoundCloud</strong><br/>Music</label></div>
 						</div>
@@ -425,7 +425,7 @@ function modRights($engine, $comm, $deriv) {
                         <div class="four columns omega">
 						<div class="engine">
 							<div class="engineButton">
-								<button onclick="setEngine(this)" name="engine" value="thingiverse" id="thingiverse"></button>
+								<button onclick="setEngine(this)" name="engine" value="thingiverse" id="thingiverse" aria-label="Thingiverse"></button>
 							</div>
 							<div class="engineDesc"><label for="thingiverse"><strong>Thingiverse</strong><br/>3D Model</label></div>
 						</div>
@@ -435,7 +435,7 @@ function modRights($engine, $comm, $deriv) {
 						<div class="four columns alpha">
 						<div class="engine">
 							<div class="engineButton">
-								<button onclick="setEngine(this)" name="engine" value="wikimediacommons" id="wikimediacommons"></button>
+								<button onclick="setEngine(this)" name="engine" value="wikimediacommons" id="wikimediacommons" aria-label="Wikimedia Commons"></button>
 							</div>
 							<div class="engineDesc"><label for="wikimediacommons"><strong>Wikimedia Commons</strong><br/>Media</label></div>
 						</div>
@@ -444,7 +444,7 @@ function modRights($engine, $comm, $deriv) {
 						<div class="four columns">
 						<div class="engine">
 							<div class="engineButton">
-								<button onclick="setEngine(this)" name="engine" value="youtube" id="youtube"></button>
+								<button onclick="setEngine(this)" name="engine" value="youtube" id="youtube" aria-label="YouTube"></button>
 							</div>
 							<div class="engineDesc"><label for="youtube"><strong>YouTube</strong><br/>Video</label></div>
 						</div>


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
Fixes #155  by @JennySimen 

## Description
<!-- Concisely describe what the pull request does. -->
This pull request adds the aria-label attribute of each engine button with it's respective engine name as value. This in turn significantly increases the accessibility tests on https://web.dev/.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

- Open the lighthouse tool 
- Run accessibility tests.
- Make sure `Buttons do not have an accessible name` does not display.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
