### PR TITLE
use bash instead of dash for better process control

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,9 @@ services:
 
   web:
     build: dev/web
-    command: sh -c "
+    command: /bin/bash -c "
       echo 'Starting static webserver at http://127.0.0.1:8080/'
-      && httpd-foreground
+      && /usr/local/bin/httpd-foreground
       "
     container_name: cc-search-web
     ports:


### PR DESCRIPTION
## Description
- use bash instead of dash (`/bin/sh`) for better process control
  - 🚀 **reduces container stop time from 10 seconds to 1.2 seconds**
    - 10 seconds is the default time for `stop_grace_period`
- use full paths for commands

## Technical details
- [Compose file version 2 reference](https://docs.docker.com/compose/compose-file/compose-file-v2/)
  - [`command`](https://docs.docker.com/compose/compose-file/compose-file-v2/#command)
  - [`init`](https://docs.docker.com/compose/compose-file/compose-file-v2/#init)
  - [`stop_grace_period`](https://docs.docker.com/compose/compose-file/compose-file-v2/#stop_grace_period)
- [Run multiple services in a container](https://docs.docker.com/config/containers/multi-service_container/)
  > The container’s main process is responsible for managing all processes that it starts. In some cases, the main process isn’t well-designed, and doesn’t handle “reaping” (stopping) child processes gracefully when the container exits. If your process falls into this category, you can use the `--init` option when you run the container.
  - using `init: true` with dash (`/bin/sh`) did not work
- [Dash - Almquist shell - Wikipedia](https://en.wikipedia.org/wiki/Almquist_shell#Dash)
  - [DashAsBinSh - Ubuntu Wiki](https://wiki.ubuntu.com/DashAsBinSh)

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
