### PR TITLE
descriptive section added for what CC search is about

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -54,6 +54,37 @@
   width: 100%; /* Full width on small screens */
 }
 
+.search-info {
+  border-radius: 5px;
+  margin-top: 5rem;
+  padding: 0rem 0rem 2rem 3rem;
+  font-family: "Inter", sans-serif;
+  line-height: 1.6;
+}
+
+.search-info h1 {
+  font-size: 2rem;
+  font-weight: bold;
+  margin: 0 15rem 1rem 0rem;
+  text-transform: uppercase;
+  background-color: #636060;
+  color: white;
+  padding-left: 1rem;
+  border-radius: 5px;
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
+}
+
+.search-info p {
+  max-width: 50%;
+  font-size: 1.3rem;
+  margin: 0;
+  color: rgb(21, 20, 20);
+}
+
+.search-info .strong {
+  color: rgba(245, 245, 83, 0.937);
+}
+
 /* Responsive Design */
 @media (min-width: 601px) {
   .body-search {

--- a/src/index.html
+++ b/src/index.html
@@ -144,6 +144,20 @@
     </header>
     <main>
       <span id="main-content-marker"></span>
+      <div class="search-info">
+        <h1>
+          Explore <stromg class="strong"> Creative Commons </stromg>Licensed
+          Content
+        </h1>
+        <p>
+          CC Search offers a powerful tool for discovering a wide range of
+          Creative Commons licensed works, including images, audio, video, and
+          other media. Users can easily search and filter content that is free
+          to use and adapt, with proper attribution. It simplifies finding
+          high-quality, openly licensed resources for creators and educators
+          around the world.
+        </p>
+      </div>
       <form
         id="searchForm"
         class="body-cont">


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'.  -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #175  by @PreciousOritsedere 

## Description
<!-- Concisely describe what the pull request does. -->
This pull request addresses the issue of the CC Search not having a descriptive section or page. It implements a dedicated section that provides users with clear information about CC Search, enhancing the user experience and understanding of the tool.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->
1. Created a new component for the CC Search About Page, which includes detailed information on the purpose and functionality of CC Search.
2. Added a new <div> element within the main tag to house the descriptive content, ensuring a clear layout and structure for the page.
3. Styled the new section using a dedicated class in style.css, leveraging the rem unit for improved responsiveness across various screen sizes.
4. Ensured the new About Page aligns visually with the overall design of the CC Search platform by incorporating consistent styling and layout principles.
5. Implemented responsive design techniques to maintain usability and aesthetics across different devices, enhancing the user experience.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->
Verified the implementation by running the application on a live server. Used the "Go Live" feature in VSCode to view and interact with the new About Page in the browser, ensuring all elements display correctly and function as intended.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->
the UI before 
![Screenshot 2024-10-03 at 16 47 10](https://github.com/user-attachments/assets/1ca42cda-afcb-4c52-a8eb-e7fe5918bbad)
and now after adding the descriptive section
![Screenshot 2024-10-03 at 16 48 07](https://github.com/user-attachments/assets/d0355b79-a3a0-41d3-9158-5b6d57d52d64)


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
