### PR TITLE
corrected the bug for html inconsistency from body>header>main to bod…

### DIFF
--- a/src/assets/vocabulary/css/vocabulary.css
+++ b/src/assets/vocabulary/css/vocabulary.css
@@ -178,7 +178,7 @@ body > header {
 /* style product identity typesetting */
 .masthead .identity-logo.product {
     width: initial;
-    position: relative;
+    position: relative; 
     text-indent: 42px;
     padding-top: 7px;
     box-sizing: border-box;
@@ -1806,7 +1806,7 @@ main > header {
     padding-top: 2em;
     padding-bottom: 1em;
     position: relative;
-
+   
     text-align: center;
 }
 
@@ -1814,11 +1814,11 @@ main > header:before {
     width: 100vw;
     height: 100%;
     position: absolute;
-    left: -33.333%;
+    /* left: -33.333%; */
     top: 0;
     z-index: -1;
     content: "";
-
+    
     background: #F5F5F5;
 }
 

--- a/src/index.html
+++ b/src/index.html
@@ -37,112 +37,112 @@
       href="#main-content-marker"
       >Skip to content</a
     >
-    <header>
-      <div class="masthead">
-        <h1>
-          <a
-            class="identity-logo product"
-            href="#"
-            >Search Portal</a
-          >
-        </h1>
-        <button class="expand-menu">Menu</button>
-        <nav class="ancilliary-menu">
-          <ul>
-            <li>
-              <a
-                class="donate icon-attach fa-heart"
-                href="https://www.classy.org/give/313412/#!/donation/checkout?c_src=website&c_src2=top-of-page-banner"
-                target="_blank"
-                >Donate</a
-              >
-            </li>
-            <li><button class="explore">Explore CC</button></li>
-          </ul>
-        </nav>
-      </div>
-      <div class="explore-panel">
-        <!-- (optional main CC logo, p, link on non-home site back to main site) -->
-        <aside>
-          <a
-            class="identity-logo"
-            href="https://creativecommons.org"
-            >Creative Commons</a
-          >
-          <h2>Our Work Relies On You!</h2>
-          <p>Help us keep the internet free and open.</p>
-        </aside>
-
-        <nav class="explore-menu">
-          <ul>
-            <li>
-              <a
-                href="https://network.creativecommons.org/"
-                target="_blank"
-                >Global Network</a
-              >
-              <p>Join a global community working to strengthen the Commons</p>
-            </li>
-            <li>
-              <a
-                href="https://certificate.creativecommons.org/"
-                target="_blank"
-                >Certificate</a
-              >
-              <p>
-                Become an expert in creating and engaging with openly licensed
-                materials
-              </p>
-            </li>
-            <li>
-              <a
-                href="https://summit.creativecommons.org/"
-                target="_blank"
-                >Global Summit</a
-              >
-              <p>
-                Attend our annual event, promoting the power of open licensing
-              </p>
-            </li>
-            <li>
-              <a
-                href="https://creativecommons.org/choose"
-                target="_blank"
-                >Chooser</a
-              >
-              <p>Get help choosing the appropriate license for your work</p>
-            </li>
-            <!--
-                <li>
-                    <a href="#" target="_blank">Search Portal</a>
-                    <p>Find engines to search openly licensed material for creative and educational reuse</p>
-                </li>
-                -->
-            <li>
-              <a
-                href="https://opensource.creativecommons.org/"
-                target="_blank"
-                >Open Source</a
-              >
-              <p>
-                Help us build products that maximize creativity and innovation
-              </p>
-            </li>
-          </ul>
-        </nav>
-      </div>
-
-      <!--
-      <nav class="navbar">
-        <div class="navbar-brand">
-          <a href="/">
-            <img src="assets/images/cc-logo.svg" alt="cc logo" />
-          </a>
-        </div>
-      </nav>
--->
-    </header>
     <main>
+      <header>
+        <div class="masthead">
+          <h1>
+            <a
+              class="identity-logo product"
+              href="#"
+              >Search Portal</a
+            >
+          </h1>
+          <button class="expand-menu">Menu</button>
+          <nav class="ancilliary-menu">
+            <ul>
+              <li>
+                <a
+                  class="donate icon-attach fa-heart"
+                  href="https://www.classy.org/give/313412/#!/donation/checkout?c_src=website&c_src2=top-of-page-banner"
+                  target="_blank"
+                  >Donate</a
+                >
+              </li>
+              <li><button class="explore">Explore CC</button></li>
+            </ul>
+          </nav>
+        </div>
+        <div class="explore-panel">
+          <!-- (optional main CC logo, p, link on non-home site back to main site) -->
+          <aside>
+            <a
+              class="identity-logo"
+              href="https://creativecommons.org"
+              >Creative Commons</a
+            >
+            <h2>Our Work Relies On You!</h2>
+            <p>Help us keep the internet free and open.</p>
+          </aside>
+  
+          <nav class="explore-menu">
+            <ul>
+              <li>
+                <a
+                  href="https://network.creativecommons.org/"
+                  target="_blank"
+                  >Global Network</a
+                >
+                <p>Join a global community working to strengthen the Commons</p>
+              </li>
+              <li>
+                <a
+                  href="https://certificate.creativecommons.org/"
+                  target="_blank"
+                  >Certificate</a
+                >
+                <p>
+                  Become an expert in creating and engaging with openly licensed
+                  materials
+                </p>
+              </li>
+              <li>
+                <a
+                  href="https://summit.creativecommons.org/"
+                  target="_blank"
+                  >Global Summit</a
+                >
+                <p>
+                  Attend our annual event, promoting the power of open licensing
+                </p>
+              </li>
+              <li>
+                <a
+                  href="https://creativecommons.org/choose"
+                  target="_blank"
+                  >Chooser</a
+                >
+                <p>Get help choosing the appropriate license for your work</p>
+              </li>
+              <!--
+                  <li>
+                      <a href="#" target="_blank">Search Portal</a>
+                      <p>Find engines to search openly licensed material for creative and educational reuse</p>
+                  </li>
+                  -->
+              <li>
+                <a
+                  href="https://opensource.creativecommons.org/"
+                  target="_blank"
+                  >Open Source</a
+                >
+                <p>
+                  Help us build products that maximize creativity and innovation
+                </p>
+              </li>
+            </ul>
+          </nav>
+        </div>
+  
+        <!--
+        <nav class="navbar">
+          <div class="navbar-brand">
+            <a href="/">
+              <img src="assets/images/cc-logo.svg" alt="cc logo" />
+            </a>
+          </div>
+        </nav>
+  -->
+      </header>
       <span id="main-content-marker"></span>
       <form
         id="searchForm"


### PR DESCRIPTION
…y>main>header

## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'.  -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #230 by @Dev-JoyA

## Description
<!-- Concisely describe what the pull request does. -->
The initial structure was incorrect and did not follow the layout guidelines outlined in the Vocabulary documentation. As a result, the search portal has an inconsistent HTML structure, impacting both accessibility and content organization.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->

1. Moved the header inside the <main> tag to follow the appropriate structure as outlined in the Vocabulary documentation.
2. Noticed a display issue where the header wasn’t rendering correctly due to a minor CSS error (see screenshot below).
3. Edited the styles associated with the <main> tag in vocabulary.css to improve the layout and ensure proper display.
4. The background color of the header was initially showing only halfway, which affected the overall UI design. After the update, the display issue was resolved. Screenshots are provided to show the before and after comparison.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->
I ran the code in my browser using Live Server in VSCode to test the UI changes. This allowed me to visually confirm that the updates to the structure and styling were correctly applied.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->
before correction
![Screenshot 2024-10-04 at 10 37 08](https://github.com/user-attachments/assets/685a199f-972f-4eae-bbfe-16a7ea88f193)
After correction
![Screenshot 2024-10-04 at 10 24 10](https://github.com/user-attachments/assets/c66ab517-4a0f-4f11-8a2f-fea7ed94bf77)
After correcting the display in css
![Screenshot 2024-10-04 at 10 24 24](https://github.com/user-attachments/assets/bddf0278-4515-4658-8fc1-783b44ae3aa7)



## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
