### PR TITLE
Resolved Inconsistent Border Thickness for Openverse Search Button

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -52,8 +52,12 @@
   font-weight: 400;
   padding: 14px;
   width: 100%; /* Full width on small screens */
+  transition: transform 0.22s;
 }
-
+.search-button:hover {
+  transform: scale(1.1, 1.1);
+  filter: invert(0.1);
+}
 /* Responsive Design */
 @media (min-width: 601px) {
   .body-search {

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -135,10 +135,6 @@
   background-color: #ddd;
 }
 
-#openverse-label {
-  border-width: 3px;
-}
-
 /* FOOTER */
 
 body > footer {

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -52,9 +52,11 @@
   font-weight: 400;
   padding: 14px;
   width: 100%; /* Full width on small screens */
+}
+.btn-hover {
   transition: transform 0.22s;
 }
-.search-button:hover {
+.btn-hover:hover {
   transform: scale(1.1, 1.1);
   filter: invert(0.1);
 }

--- a/src/index.html
+++ b/src/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -46,10 +46,10 @@
             >Search Portal</a
           >
         </h1>
-        <button class="expand-menu">Menu</button>
+        <button class="expand-menu btn-hover">Menu</button>
         <nav class="ancilliary-menu">
           <ul>
-            <li>
+            <li class="btn-hover">
               <a
                 class="donate icon-attach fa-heart"
                 href="https://www.classy.org/give/313412/#!/donation/checkout?c_src=website&c_src2=top-of-page-banner"
@@ -57,7 +57,7 @@
                 >Donate</a
               >
             </li>
-            <li><button class="explore">Explore CC</button></li>
+            <li><button class="explore btn-hover">Explore CC</button></li>
           </ul>
         </nav>
       </div>
@@ -156,7 +156,7 @@
               name="query"
               value=""
               placeholder="Enter your search query" />
-            <button class="search-button">Search</button>
+            <button class="search-button btn-hover">Search</button>
           </div>
           <div
             class="search-checkbox"
@@ -564,7 +564,7 @@
             type="submit"
             value="subscribe"
             id="mc-embedded-subscribe"
-            class="button small" />
+            class="button small btn-hover" />
         </form>
       </div>
 
@@ -572,7 +572,7 @@
         <h2>Support Our Work</h2>
         <p>Our work relies on you! Help us keep the Internet free and open.</p>
         <a
-          class="donate icon-attach cc-heart-filled"
+          class="donate icon-attach cc-heart-filled btn-hover"
           href="https://www.classy.org/give/313412/#!/donation/checkout?c_src=website&c_src2=top-of-page-banner"
           target="_blank"
           >Donate Now</a


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'.  -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #254  by @mo-gbolahan

## Description
This PR resolves the issue where the Openverse search button had a thicker border than other buttons on the page, causing it to stand out inappropriately even without interaction. The border thickness has been adjusted to match the uniform style of other buttons, improving the visual consistency and user experience.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->

## Tests

1. Navigate to the search page with the Openverse search button.
2. Confirm that the button’s border thickness matches other buttons in its default state.
3. Hover over or click the button to ensure the visual feedback works as expected.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->
![Screenshot (28)](https://github.com/user-attachments/assets/7b7dd9c4-5586-4969-8e6e-3ab151b4913f)

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [ ] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
