### PR TITLE
ccMixter search incorrect data response resolved

### DIFF
--- a/src/assets/js/script.js
+++ b/src/assets/js/script.js
@@ -12,7 +12,7 @@ document.addEventListener("DOMContentLoaded", function (e) {
     form.commercial = document.getElementById("commercial").checked;
     form.modify = document.getElementById("modify").checked;
     selectedEngine = document.querySelector(
-      'input[name="search-engine"]:checked'
+      'input[name="search-engine"]:checked',
     );
     form.searchEngine = selectedEngine.value;
     form.searchEngineURL = selectedEngine.dataset.url;

--- a/src/assets/js/script.js
+++ b/src/assets/js/script.js
@@ -12,7 +12,7 @@ document.addEventListener("DOMContentLoaded", function (e) {
     form.commercial = document.getElementById("commercial").checked;
     form.modify = document.getElementById("modify").checked;
     selectedEngine = document.querySelector(
-      'input[name="search-engine"]:checked',
+      'input[name="search-engine"]:checked'
     );
     form.searchEngine = selectedEngine.value;
     form.searchEngineURL = selectedEngine.dataset.url;
@@ -56,11 +56,11 @@ document.addEventListener("DOMContentLoaded", function (e) {
         case "ccmixter":
           rights = "";
           if (form.commercial && form.modify) {
-            rights += "&lic=by,sa,s,splus,pd,zero";
+            rights += "&lic=by,sa,s,splus,pd,cc0";
           } else if (form.commercial) {
             rights += "&lic=open";
           } else if (form.modify) {
-            rights += "&lic=by,nc,sa,ncsa,s,splus,pd,zero";
+            rights += "&lic=by,nc,sa,ncsa,s,splus,pd,cc0";
           }
           break;
 

--- a/src/index.html
+++ b/src/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/src/index.html
+++ b/src/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />


### PR DESCRIPTION
## Fixes
- Fixes #250 by @Netacci 

## Description
Issue:
An error was encountered when attempting to include zero as a license type in the rights variable for queries to the ccMixter API. The query string that included zero resulted in an invalid request, leading to an error response from the API.

Cause:
The ccMixter API does not recognize zero as a valid license type in its query format. As zero was causing the error, the issue was identified to be a misrepresentation of the license type.

Solution:
To resolve this issue, I replaced zero with cc0 in the query string. The updated code now correctly handles the public domain license type, avoiding any query errors.

Changes made: 
1. Replaced zero with cc0 to properly represent the public domain license type.
2. Ensured that the query string is formatted correctly for the ccMixter API.

## Tests
1. After updating the license type in the query string, I tested the API request to verify that the error was resolved and the
 request was successful.
2. The API now responds correctly with the expected results when cc0 is used instead of zero.


## Screenshots
<img width="943" alt="workingCCmixter" src="https://github.com/user-attachments/assets/3a5049b9-6a4d-494e-a1e0-b3b4ba08d0b5">


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.
