### PR TITLE
Implement Custom Inline Error Message for Empty Search Field

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -67,6 +67,15 @@
   color: #FF0000; /* Red color for error */
   font-size: 0.9em;
   margin-top: 5px;
+  display: none;
+}
+
+.error-input, .error-input:focus {
+  border-color: #FF0000 !important; /* Red border for error */
+}
+
+.error-message-display {
+  display: block;
 }
 
 /* Responsive Design */
@@ -88,6 +97,9 @@
     margin-top: 0;
 
     border-radius: 0 8px 8px 0;
+  }
+  .error-message-display {
+    display: none !important;
   }
 }
 @media(min-width:480px) and (max-width:768px) {

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -59,6 +59,12 @@
   cursor: pointer;
 }
 
+.error-message {
+  color: #FF0000; /* Red color for error */
+  font-size: 0.9em;
+  margin-top: 5px;
+}
+
 /* Responsive Design */
 @media (min-width: 601px) {
   .body-search {

--- a/src/assets/js/script.js
+++ b/src/assets/js/script.js
@@ -1,18 +1,28 @@
 document.addEventListener("DOMContentLoaded", function (e) {
   const searchForm = document.getElementById("searchForm");
 
-  document.querySelector('.search-button').addEventListener('click', function(event) {
-    const queryInput = document.getElementById('query').value.trim();
+  const inputValidator = (event) => {
+    const queryInput = document.getElementById('query');
     const errorMessage = document.getElementById('error-message');
-  
-    if (!queryInput) {
+
+    // Validate input value
+    const hasInput = queryInput?.value.trim();
+
+    if (!hasInput) {
       event.preventDefault(); // Prevent form submission
       errorMessage.textContent = "Please enter a search term.";
-      errorMessage.style.display = "block";
+      errorMessage.classList.add('error-message-display');
+      queryInput?.classList.add('error-input');
     } else {
-      errorMessage.style.display = "none"; // Hide error if input is valid
+      errorMessage.classList.remove('error-message-display');
+      queryInput?.classList.remove('error-input');
     }
-  });
+  };
+
+  // Event listeners
+  document.querySelector('.search-button')?.addEventListener('click', inputValidator);
+  document.querySelector('#query')?.addEventListener('input', inputValidator);
+
 
   searchForm.addEventListener("submit", (e) => {
     e.preventDefault();
@@ -44,10 +54,6 @@ document.addEventListener("DOMContentLoaded", function (e) {
 
   // construct the URL
   function buildURL(form) {
-    if (form.query === "") {
-      alert("Please enter a search value");
-      return;
-    }
     if (form.searchEngineURL === undefined) {
       alert("Please select a search engine");
       return;

--- a/src/assets/js/script.js
+++ b/src/assets/js/script.js
@@ -1,6 +1,19 @@
 document.addEventListener("DOMContentLoaded", function (e) {
   const searchForm = document.getElementById("searchForm");
 
+  document.querySelector('.search-button').addEventListener('click', function(event) {
+    const queryInput = document.getElementById('query').value.trim();
+    const errorMessage = document.getElementById('error-message');
+  
+    if (!queryInput) {
+      event.preventDefault(); // Prevent form submission
+      errorMessage.textContent = "Please enter a search term.";
+      errorMessage.style.display = "block";
+    } else {
+      errorMessage.style.display = "none"; // Hide error if input is valid
+    }
+  });
+
   searchForm.addEventListener("submit", (e) => {
     e.preventDefault();
 

--- a/src/index.html
+++ b/src/index.html
@@ -157,6 +157,8 @@
               value=""
               placeholder="Enter your search query" />
             <button class="search-button">Search</button>
+            <!-- Placeholder for error message -->
+            <div id="error-message" class="error-message" style="display: none;"></div>
           </div>
           <div
             class="search-checkbox"

--- a/src/index.html
+++ b/src/index.html
@@ -155,10 +155,10 @@
               id="query"
               name="query"
               value=""
-              placeholder="Enter your search query" />
+              placeholder="Enter your search query"
+              required/>
+              <div id="error-message" class="error-message error-message-display"></div>
             <button class="search-button">Search</button>
-            <!-- Placeholder for error message -->
-            <div id="error-message" class="error-message" style="display: none;"></div>
           </div>
           <div
             class="search-checkbox"


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'.  -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #[issue number] by @[issue author]

## Description
<!-- Concisely describe what the pull request does. -->
This pull request addresses the issue where an empty search field caused the browser to display a native modal message that was inconsistent with the site's user experience. Instead of relying on the browser's default behavior, this PR introduces a custom inline error message to guide users to enter a search term in a more visually consistent and user-friendly manner.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->
- **JavaScript:** Added a script that listens for the "Search" button click and search field input change. It checks if the search field is empty and displays a custom error message if needed. This prevents the default modal popup from the browser.
- **HTML:** Included a <div> below the search field to display the error message when triggered.
- **CSS:** Styled the error message to match the site’s color scheme and typography for a seamless visual experience.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->
- Open the search page and leave the search field empty.
- For mobile screens, click the "Search" button and confirm that an inline error message appears below the search field saying "Please enter a search term.", and the input field is highlighted to draw attention.
- Enter a search term and verify that the error message disappears and the form is submits correctly.
- Verify that no native browser alerts appear when clicking the "Search" button.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->
Before:
<img width="890" alt="Screenshot (308)" src="https://github.com/user-attachments/assets/b8962565-69e1-4322-ae2d-22d6c7b51b4d">
<img width="477" alt="Screenshot (307)" src="https://github.com/user-attachments/assets/16cd181d-6393-4841-85da-5cc119426961">

After: 
<img width="887" alt="Screenshot (305)" src="https://github.com/user-attachments/assets/9248ec46-b55b-4098-9c83-cb8055cf0b38">
<img width="349" alt="Screenshot (304)" src="https://github.com/user-attachments/assets/168f67da-f810-4b19-bc41-c7290bfb2df2">


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
